### PR TITLE
Changed store platform and mssql img to azure edge for ARM Mac support

### DIFF
--- a/src/PythonService/Dockerfile
+++ b/src/PythonService/Dockerfile
@@ -1,5 +1,5 @@
 # Use an official Python runtime as a parent image
-FROM python:3.9-slim-buster
+FROM --platform=linux/amd64 python:3.9-slim-buster
 
 # Set the working directory to /app
 WORKDIR /app

--- a/src/docker-compose.yml
+++ b/src/docker-compose.yml
@@ -62,7 +62,7 @@ services:
 
   sqlserver:
     container_name: sqlserver
-    image: "mcr.microsoft.com/mssql/server"    
+    image: "mcr.microsoft.com/azure-sql-edge" 
     volumes:
       - sqlserverdata:/var/lib/sqlserver
   # Databases


### PR DESCRIPTION
Tested on Mac/Silicon and Linux/amd64 - To be tested on other platforms (Windows?)

For portability, this replaces  the mssql image with the azure-sql-edge image the overcome this open issue:
https://github.com/microsoft/mssql-docker/issues/668
Azure SQL Edge (with its mssql core) should work fine in a small test/demo project, may not be ok in all cases.